### PR TITLE
fix login issue in windows 11

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -39,10 +39,10 @@
   ],
   "license": "ISC",
   "devDependencies": {
-    "@nvii/typescript-config": "workspace:*",
-    "@swc/core": "^1.3.99",
     "@nvii/db": "workspace:*",
     "@nvii/env-helpers": "workspace:*",
+    "@nvii/typescript-config": "workspace:*",
+    "@swc/core": "^1.3.99",
     "@types/node": "^20.17.10",
     "@types/update-notifier": "^6.0.8",
     "commander": "^11.1.0",
@@ -59,6 +59,7 @@
     "dotenv": "^16.4.7",
     "inquirer": "^12.4.3",
     "nanoid": "^3.3.7",
+    "open": "^11.0.0",
     "ora": "^7.0.1",
     "picocolors": "^1.0.0",
     "update-notifier": "7.3.1"

--- a/packages/cli/src/commands/auth/login.ts
+++ b/packages/cli/src/commands/auth/login.ts
@@ -1,6 +1,5 @@
 import { FILENAME, checkLoginStats, API_URLS } from "@nvii/env-helpers";
 import { listen } from "async-listen";
-import { spawn } from "child_process";
 import "dotenv/config";
 import { writeFileSync, readFileSync } from "fs";
 import http from "http";
@@ -9,7 +8,7 @@ import os from "os";
 import path from "path";
 import pc from "picocolors";
 import url from "url";
-
+import open from "open";
 class UserCancellationError extends Error {
   constructor(message: string) {
     super(message);
@@ -103,8 +102,7 @@ export async function login() {
     `If something goes wrong, copy and paste this URL into your browser:\n${pc.bold(confirmationUrl.toString())}\n`
   );
 
-  spawn("open", [confirmationUrl.toString()]);
-
+  await open(confirmationUrl.toString());
   const spinner = ora("Waiting for authentication...\n").start();
 
   try {


### PR DESCRIPTION
## Fix: Cross-platform browser launch for CLI authentication

### Summary
This PR fixes an issue where the CLI authentication flow failed to open the browser on Windows. The previous implementation relied on OS-specific commands (`spawn("open")`), which only work on macOS.

The browser launch logic has been replaced with the cross-platform `open` package to ensure consistent behavior across Windows, macOS, and Linux.

---

### Changes
- Replaced OS-dependent `child_process.spawn("open")` with the `open` package
- Removed unused `spawn` import
- Ensured the authentication URL opens correctly on Windows 11

---

### Why this change?
- The `open` command is macOS-only
- Windows and Linux users could not complete authentication
- The `open` package provides a reliable, cross-platform solution
- Improves CLI usability and developer experience

---

### How it works
```ts
import open from "open";

await open(confirmationUrl.toString());
