### PR TITLE
chore: upgrade Prisma to v7 with PostgreSQL adapter

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -49,4 +49,9 @@ packages/database/generated
 
 # local todo list
 /*.todo
-.nvii/
+/*.nvii/
+
+# my local upgrade plan
+upgrade_plan.md
+# my local todo list
+/todos

--- a/packages/database/.gitignore
+++ b/packages/database/.gitignore
@@ -1,3 +1,4 @@
 .env*
 
 generated
+*/migrations

--- a/packages/database/package.json
+++ b/packages/database/package.json
@@ -20,14 +20,17 @@
     "studio": "prisma studio"
   },
   "dependencies": {
-    "@prisma/client": "6.4.1"
+    "@prisma/adapter-pg": "^7.1.0",
+    "@prisma/client": "latest",
+    "@prisma/client-runtime-utils": "^7.1.0",
+    "pg": "^8.16.3",
+    "prisma": "^7.1.0"
   },
   "devDependencies": {
     "@nvii/eslint-config": "workspace:*",
     "@nvii/typescript-config": "workspace:*",
-    "@types/node": "^25.0.1",
+    "@types/pg": "^8.16.0",
     "eslint": "^8.57.0",
-    "prisma": "6.4.1",
     "rimraf": "^5.0.5",
     "tsup": "^8.0.2",
     "tsx": "4.19.1",

--- a/packages/database/prisma/migrations/20251213202413_new_migration/migration.sql
+++ b/packages/database/prisma/migrations/20251213202413_new_migration/migration.sql
@@ -1,0 +1,212 @@
+-- CreateTable
+CREATE TABLE "users" (
+    "id" TEXT NOT NULL,
+    "name" TEXT,
+    "email" TEXT,
+    "emailVerified" BOOLEAN,
+    "image" TEXT,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+    "optsCode" TEXT,
+
+    CONSTRAINT "users_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "sessions" (
+    "id" TEXT NOT NULL,
+    "userId" TEXT NOT NULL,
+    "token" TEXT NOT NULL,
+    "expiresAt" TIMESTAMP(3) NOT NULL,
+    "ipAddress" TEXT,
+    "userAgent" TEXT,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "sessions_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "accounts" (
+    "id" TEXT NOT NULL,
+    "userId" TEXT NOT NULL,
+    "accountId" TEXT NOT NULL,
+    "providerId" TEXT NOT NULL,
+    "accessToken" TEXT,
+    "refreshToken" TEXT,
+    "accessTokenExpiresAt" TIMESTAMP(3),
+    "refreshTokenExpiresAt" TIMESTAMP(3),
+    "scope" TEXT,
+    "idToken" TEXT,
+    "password" TEXT,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "accounts_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "verifications" (
+    "id" TEXT NOT NULL,
+    "identifier" TEXT NOT NULL,
+    "value" TEXT NOT NULL,
+    "expiresAt" TIMESTAMP(3) NOT NULL,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "verifications_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "devices" (
+    "id" TEXT NOT NULL,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "userId" TEXT NOT NULL,
+    "key" TEXT NOT NULL,
+    "code" TEXT NOT NULL,
+
+    CONSTRAINT "devices_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "projects" (
+    "id" TEXT NOT NULL,
+    "name" TEXT NOT NULL,
+    "userId" TEXT NOT NULL,
+    "key" TEXT NOT NULL,
+    "deviceId" TEXT,
+    "content" JSONB,
+    "description" TEXT,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "projects_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "project_access" (
+    "projectId" TEXT NOT NULL,
+    "userId" TEXT NOT NULL,
+    "assignedAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "project_access_pkey" PRIMARY KEY ("projectId","userId")
+);
+
+-- CreateTable
+CREATE TABLE "env_versions" (
+    "id" TEXT NOT NULL,
+    "projectId" TEXT NOT NULL,
+    "content" JSONB NOT NULL,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "createdBy" TEXT NOT NULL,
+    "description" TEXT,
+    "changes" JSONB,
+    "isCurrent" BOOLEAN,
+    "branch" TEXT NOT NULL DEFAULT 'main',
+
+    CONSTRAINT "env_versions_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "env_version_tag" (
+    "id" TEXT NOT NULL,
+    "projectId" TEXT NOT NULL,
+    "versionId" TEXT NOT NULL,
+    "name" TEXT NOT NULL,
+    "description" TEXT,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "env_version_tag_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "env_version_branches" (
+    "id" TEXT NOT NULL,
+    "name" TEXT NOT NULL,
+    "projectId" TEXT NOT NULL,
+    "baseVersionId" TEXT NOT NULL,
+    "isActive" BOOLEAN NOT NULL DEFAULT false,
+    "description" TEXT,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "env_version_branches_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "_ProjectAccess" (
+    "A" TEXT NOT NULL,
+    "B" TEXT NOT NULL,
+
+    CONSTRAINT "_ProjectAccess_AB_pkey" PRIMARY KEY ("A","B")
+);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "users_email_key" ON "users"("email");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "projects_userId_name_key" ON "projects"("userId", "name");
+
+-- CreateIndex
+CREATE INDEX "env_versions_projectId_createdAt_idx" ON "env_versions"("projectId", "createdAt" DESC);
+
+-- CreateIndex
+CREATE INDEX "env_versions_createdBy_idx" ON "env_versions"("createdBy");
+
+-- CreateIndex
+CREATE INDEX "env_versions_branch_idx" ON "env_versions"("branch");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "env_version_tag_projectId_name_key" ON "env_version_tag"("projectId", "name");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "env_version_branches_projectId_name_key" ON "env_version_branches"("projectId", "name");
+
+-- CreateIndex
+CREATE INDEX "_ProjectAccess_B_index" ON "_ProjectAccess"("B");
+
+-- AddForeignKey
+ALTER TABLE "sessions" ADD CONSTRAINT "sessions_userId_fkey" FOREIGN KEY ("userId") REFERENCES "users"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "accounts" ADD CONSTRAINT "accounts_userId_fkey" FOREIGN KEY ("userId") REFERENCES "users"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "devices" ADD CONSTRAINT "devices_userId_fkey" FOREIGN KEY ("userId") REFERENCES "users"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "projects" ADD CONSTRAINT "projects_userId_fkey" FOREIGN KEY ("userId") REFERENCES "users"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "projects" ADD CONSTRAINT "projects_deviceId_fkey" FOREIGN KEY ("deviceId") REFERENCES "devices"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "project_access" ADD CONSTRAINT "project_access_projectId_fkey" FOREIGN KEY ("projectId") REFERENCES "projects"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "project_access" ADD CONSTRAINT "project_access_userId_fkey" FOREIGN KEY ("userId") REFERENCES "users"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "env_versions" ADD CONSTRAINT "env_versions_projectId_fkey" FOREIGN KEY ("projectId") REFERENCES "projects"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "env_versions" ADD CONSTRAINT "env_versions_createdBy_fkey" FOREIGN KEY ("createdBy") REFERENCES "users"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "env_version_tag" ADD CONSTRAINT "env_version_tag_projectId_fkey" FOREIGN KEY ("projectId") REFERENCES "projects"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "env_version_tag" ADD CONSTRAINT "env_version_tag_versionId_fkey" FOREIGN KEY ("versionId") REFERENCES "env_versions"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "env_version_branches" ADD CONSTRAINT "env_version_branches_projectId_fkey" FOREIGN KEY ("projectId") REFERENCES "projects"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "env_version_branches" ADD CONSTRAINT "env_version_branches_baseVersionId_fkey" FOREIGN KEY ("baseVersionId") REFERENCES "env_versions"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "_ProjectAccess" ADD CONSTRAINT "_ProjectAccess_A_fkey" FOREIGN KEY ("A") REFERENCES "projects"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "_ProjectAccess" ADD CONSTRAINT "_ProjectAccess_B_fkey" FOREIGN KEY ("B") REFERENCES "users"("id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/packages/database/prisma/schema.prisma
+++ b/packages/database/prisma/schema.prisma
@@ -1,9 +1,5 @@
-// This is your Prisma schema file,
-// learn more about it in the docs: https://pris.ly/d/prisma-schema
-
 datasource db {
   provider = "postgresql"
-  url      = env("DATABASE_URL")
 }
 
 generator client {
@@ -15,6 +11,7 @@ model User {
   id               String          @id @default(cuid())
   name             String?
   email            String?         @unique
+  username         String?         @unique
   emailVerified    Boolean?
   image            String?
   createdAt        DateTime        @default(now())

--- a/packages/database/src/client.ts
+++ b/packages/database/src/client.ts
@@ -1,8 +1,27 @@
+// packages/database/src/client.ts
+
 import { PrismaClient } from "../generated/client";
+import { PrismaPg } from "@prisma/adapter-pg"; // Import the adapter
+import pg from "pg"; // Import the driver
+
+// Ensure environment variables are loaded if this file runs standalone
+// import 'dotenv/config'; // Add this line if needed, based on your env setup
 
 const globalForPrisma = globalThis as unknown as { prisma: PrismaClient };
 
-export const db = globalForPrisma.prisma || new PrismaClient();
+// Define the connection string (it reads from process.env.DATABASE_URL)
+const connectionString = process.env.DATABASE_URL;
+
+if (!connectionString) {
+  throw new Error("DATABASE_URL environment variable is not set.");
+}
+
+// Instantiate the driver and adapter
+const pool = new pg.Pool({ connectionString });
+const adapter = new PrismaPg(pool);
+
+// Pass the adapter to the PrismaClient constructor
+export const db = globalForPrisma.prisma || new PrismaClient({ adapter });
 
 if (process.env.NODE_ENV !== "production") globalForPrisma.prisma = db;
 

--- a/packages/database/src/seed.ts
+++ b/packages/database/src/seed.ts
@@ -1,6 +1,6 @@
 import { prisma } from "./client";
 
-import type { User } from "../generated/client";
+import type { User } from "../prisma/generated/client";
 
 const DEFAULT_USERS = [
   // Add your own user to pre-populate the database with


### PR DESCRIPTION
- Update prisma from 6.4.1 to ^7.1.0
- Add @prisma/adapter-pg and @prisma/client-runtime-utils
- Add pg driver and @types/pg
- Use PrismaPg adapter in client.ts
- Remove url from schema (v7 compatibility)